### PR TITLE
Generate build output automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "build-watch": "nodemon --watch src --ext ts --exec yarn build",
     "pretest": "yarn run build",
     "test": "mocha ./lib/test/**/*.test.js",
+    "preversion": "yarn run build",
+    "postversion": "git push --follow-tags && yarn publish",
     "test-watch": "nodemon --watch src --ext ts --exec yarn test"
   },
   "author": "",


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description

> I think we should adopt an approach like https://github.com/typestyle/typestyle/blob/master/package.json#L14-L15 where creating a new version via yarn version runs the preversion and postversion scripts (if configured), so that the build output (lib directories) is generated. This way, if anyone were consuming the package via the npm registry they would install a version that had JavaScript files alongside Typescript

Resolve #12 

### References
* #12 

### Risks
* N/A