### PR TITLE
Support -v option for displaying version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,8 @@ const cli = meow(
   {
     alias: {
       p: "path",
-      r: "replace-v1"
+      r: "replace-v1",
+      v: "version"
     }
   }
 );


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Adds an alias for `-v`, which will resolve to `--version` so that the package version can be displayed using either (common) option.

### Risks
* N/A