### PR TITLE
Fix replace v1

### DIFF
--- a/src/steps/commit_changes.ts
+++ b/src/steps/commit_changes.ts
@@ -15,7 +15,7 @@ export default async (options: Map<string, any>) => {
     const v1Files: string[] = sync("/*", {
       dot: true,
       root: `${src}`,
-      ignore: [`${src}/v2/**`, `${src}/v2`, `${src}/**/.git*/**`]
+      ignore: [`${src}/v2/**`, `${src}/v2`, `${src}/v1`, `${src}/**/.git*/**`]
     });
     // Create the v1 directory
     mkdir("-p", `${src}/v1`);

--- a/src/steps/commit_changes.ts
+++ b/src/steps/commit_changes.ts
@@ -22,7 +22,7 @@ export default async (options: Map<string, any>) => {
     // Move all the v1 files across to the backup directory
     mv(v1Files, `${src}/v1/`);
     // Move the v2 files to the root directory
-    mv("-n", `${src}/v2/*`, `${src}/`);
+    mv("-n", [`${src}/v2/*`, `${src}/v2/.[!.]*`], `${src}/`);
     // Remove the old v2 directory
     rm("-fR", `${src}/v2`);
     // Set the new dest on to options so that scripts will

--- a/src/test/steps/commit_changes.test.ts
+++ b/src/test/steps/commit_changes.test.ts
@@ -16,6 +16,7 @@ describe("commit changes", () => {
     editor = fsEditor.create(memFs.create());
     editor.write(`${src}/app.js`, "");
     editor.write(`${src}/v2/src/javascripts/legacy_app.js`, "");
+    editor.write(`${src}/v2/.babelrc`, "");
     options = Map({ src, editor });
   });
 
@@ -42,6 +43,9 @@ describe("commit changes", () => {
       expect(dest).to.equal(src);
       expect(test("-e", `${dest}/v2/src/javascripts/legacy_app.js`)).to.be.false;
       expect(test("-e", `${dest}/src/javascripts/legacy_app.js`)).to.be.true;
+      
+      expect(test("-e", `${dest}/v2/.babelrc`)).to.be.false;
+      expect(test("-e", `${dest}/.babelrc`)).to.be.true;
     });
 
     it("should backup the v1 app source files to a v1 folder", async () => {


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Migrator doesn't move dot files from `v2` directory to the project's root when run with `--replace-v1` flag and webpack build fails.
Fixes: #45 

### Tasks
- [x] Write tests

### Risks
* [low] commit step will fail if there are no dot files in `v2` directory