### PR TITLE
[AF-992] Error while running zat migrate

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,7 +81,7 @@ export function requireStatementProcessorFactory(
   return (code: Buffer | string, filePath: string) => {
     const ast = parse(code.toString());
     const filePathWithoutSrc = filePath.replace(
-      new RegExp(`${join(src, sep)}`),
+      `${join(src, sep)}`,
       ""
     );
     const fileDir = dirname(filePathWithoutSrc);


### PR DESCRIPTION
:v:

### Description
An OS-specific path separator was causing an incorrectly formed RegExp on Windows.  This PR falls back to just using a string literal, not a RegExp.

Resolves #47.

### Tasks
- [x] ~~Write tests~~ Existing tests should provide sufficient coverage

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-992

### Risks
* [low] The original RegExp was just doing very basic String matching anyway